### PR TITLE
【バックエンド】AIヒント生成API・模範解答APIの追加／OpenAI連携 (#feature/hint-api)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,3 +63,9 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+#AI用
+OPENAI_API_KEY=your_openai_key_here
+OPENAI_API_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-4o
+

--- a/backend/app/Http/Controllers/HintController.php
+++ b/backend/app/Http/Controllers/HintController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class HintController extends Controller
+{
+    /** POST /api/hints/generate */
+    public function generate(Request $request)
+    {
+        /* ---------- 1. バリデーション ---------- */
+        $request->validate([
+            'prompt'          => 'required|string',
+            'history'         => 'array',
+            'history.*.role'  => 'in:user,assistant',
+            'history.*.text'  => 'string',
+            'shown_step'      => 'integer|min:0',
+        ]);
+
+        $shownStep = (int) $request->input('shown_step', 0);
+        $prompt    = $request->input('prompt');
+
+        /* ---------- 2. system プロンプト ---------- */
+        $sys = <<<PROMPT
+あなたは優秀なプログラミング講師です。
+回答は **必ず日本語** で行い、**有効な JSON のみ** を返してください。
+コードブロックや前後の余計な文字列は禁止です。
+
+出力スキーマ (shown_step = %d):
+
+{
+  "algorithm":     "アルゴリズム名 (不明なら \"unknown\")",
+  "overall_steps": ["手順1", "手順2", ...],
+  "feedback":      "今回ユーザーが送った内容へのフィードバック (shown_step が 0 のときは空文字列)",
+  "next_hint":     { "step": %d, "text": "ヒントを 1 文だけ" },
+  "solved":        <true|false>   // ユーザーが完成コードを提出 or 「解けた」と明言したときのみ true
+}
+PROMPT;
+        $sys = sprintf($sys, $shownStep, $shownStep + 1);
+
+        /* ---------- 3. 会話履歴 ---------- */
+        $messages   = [['role' => 'system', 'content' => $sys]];
+        foreach ($request->input('history', []) as $h) {
+            $messages[] = [
+                'role'    => $h['role'] === 'assistant' ? 'assistant' : 'user',
+                'content' => $h['text'],
+            ];
+        }
+        $messages[] = ['role' => 'user', 'content' => $prompt];
+
+        /* ---------- 4. OpenAI 呼び出し ---------- */
+        $res = OpenAI::chat()->create([
+            'model'           => env('OPENAI_MODEL', 'gpt-4o'),
+            'messages'        => $messages,
+            'response_format' => ['type' => 'json_object'],
+            'max_tokens'      => 900,
+            'temperature'     => 0.4,
+        ]);
+
+        $raw  = $res['choices'][0]['message']['content'] ?? '{}';
+        $data = json_decode($raw, true);
+
+        /* ---------- 5. JSON 修復（1 回） ---------- */
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            Log::warning('JSON parse fail – retry', ['raw' => $raw]);
+
+            $fix = OpenAI::chat()->create([
+                'model'           => env('OPENAI_MODEL', 'gpt-4o'),
+                'messages'        => [
+                    ['role' => 'system', 'content' => '次の文字列を**純粋な JSON** に直して返してください。'],
+                    ['role' => 'user',   'content' => $raw],
+                ],
+                'response_format' => ['type' => 'json_object'],
+                'temperature'     => 0,
+                'max_tokens'      => 2000,
+            ]);
+
+            $raw  = $fix['choices'][0]['message']['content'] ?? '{}';
+            $data = json_decode($raw, true);
+        }
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return response()->json([
+                'status'  => 'fail',
+                'message' => 'AI が正しい JSON を返しませんでした。',
+                'raw'     => $raw,
+            ], 500);
+        }
+
+        /* ---------- 6. フィードバック & solved のサニタイズ ---------- */
+        if ($shownStep === 0) {
+            $data['feedback'] = '';          // 初回は空文字列に
+        }
+        if (!$this->userClaimsSolved($prompt) && $shownStep === 0) {
+            $data['solved'] = false;         // 早期 solved=true を抑止
+        }
+
+        /* ---------- 7. 正常レス ---------- */
+        return response()->json([
+            'status' => 'success',
+            'data'   => $data,
+        ]);
+    }
+
+    private function userClaimsSolved(string $t): bool
+    {
+        return (bool) preg_match('/(解決|解けた|ac|accepted|pass|passed|done)/iu', $t);
+    }
+}

--- a/backend/app/Http/Controllers/ModelAnswerController.php
+++ b/backend/app/Http/Controllers/ModelAnswerController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class ModelAnswerController extends Controller
+{
+    /**
+     * 1 つの質問（ prompt ）を受け取り、模範解答と解説を JSON で返す。
+     * 返却スキーマ:
+     * {
+     *   "answer_text": "…",
+     *   "explanation": "…"
+     * }
+     */
+    public function generate(Request $request)
+    {
+        // 1) 入力チェック
+        $request->validate([
+            'prompt' => 'required|string',
+        ]);
+
+        // 2) メッセージ準備（JSON 強制）
+        $messages = [
+            [
+                'role'    => 'system',
+                'content' => <<<SYS
+あなたは優秀なプログラミング講師です。
+必ず **有効な JSON オブジェクトのみ** を返してください（コードブロック禁止）。
+スキーマ:
+{
+  "answer_text": "最終的な模範解答のコードまたはアルゴリズム手順",
+  "explanation": "なぜその解法になるのかを日本語で詳しく解説"
+}
+SYS
+            ],
+            [
+                'role'    => 'user',
+                'content' => $request->input('prompt'),
+            ],
+        ];
+
+        // 3) OpenAI 呼び出し
+        $res = OpenAI::chat()->create([
+            'model'           => env('OPENAI_MODEL', 'gpt-4o'),
+            'messages'        => $messages,
+            'response_format' => ['type' => 'json_object'],
+            'temperature'     => 0.3,
+            'max_tokens'      => 1500,
+        ]);
+
+        $raw  = $res['choices'][0]['message']['content'] ?? '{}';
+        $json = json_decode($raw, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            Log::error('ModelAnswer JSON parse error', ['raw' => $raw]);
+
+            return response()->json([
+                'status'  => 'fail',
+                'message' => 'AI が正しい JSON を返しませんでした。',
+                'raw'     => $raw,
+            ], 500);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'data'   => $json,
+        ]);
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -9,7 +9,8 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.1",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "openai-php/laravel": "^0.14.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "015e02e23a490fcf9d86230851cba120",
+    "content-hash": "db67acdc4518ab5280a8fd7056826015",
     "packages": [
         {
             "name": "brick/math",
@@ -2570,6 +2570,321 @@
                 }
             ],
             "time": "2025-05-08T08:14:37+00:00"
+        },
+        {
+            "name": "openai-php/client",
+            "version": "v0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openai-php/client.git",
+                "reference": "c176c964902272649c10f092e2513bc12179161f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openai-php/client/zipball/c176c964902272649c10f092e2513bc12179161f",
+                "reference": "c176c964902272649c10f092e2513bc12179161f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0",
+                "php-http/discovery": "^1.20.0",
+                "php-http/multipart-stream-builder": "^1.4.2",
+                "psr/http-client": "^1.0.3",
+                "psr/http-client-implementation": "^1.0.1",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message": "^1.1.0|^2.0.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.9.3",
+                "guzzlehttp/psr7": "^2.7.1",
+                "laravel/pint": "^1.22.0",
+                "mockery/mockery": "^1.6.12",
+                "nunomaduro/collision": "^8.8.0",
+                "pestphp/pest": "^3.8.2|^4.0.0",
+                "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0",
+                "pestphp/pest-plugin-type-coverage": "^3.5.1|^4.0.0",
+                "phpstan/phpstan": "^1.12.25",
+                "symfony/var-dumper": "^7.2.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/OpenAI.php"
+                ],
+                "psr-4": {
+                    "OpenAI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri"
+                }
+            ],
+            "description": "OpenAI PHP is a supercharged PHP API client that allows you to interact with the Open AI API",
+            "keywords": [
+                "GPT-3",
+                "api",
+                "client",
+                "codex",
+                "dall-e",
+                "language",
+                "natural",
+                "openai",
+                "php",
+                "processing",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/openai-php/client/issues",
+                "source": "https://github.com/openai-php/client/tree/v0.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-24T10:49:48+00:00"
+        },
+        {
+            "name": "openai-php/laravel",
+            "version": "v0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openai-php/laravel.git",
+                "reference": "cee51d2502c1ff50580269db5a773cd84be76066"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openai-php/laravel/zipball/cee51d2502c1ff50580269db5a773cd84be76066",
+                "reference": "cee51d2502c1ff50580269db5a773cd84be76066",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.9.3",
+                "laravel/framework": "^11.29|^12.12",
+                "openai-php/client": "^0.14.0",
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.22.0",
+                "pestphp/pest": "^3.8.2|^4.0.0",
+                "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0",
+                "phpstan/phpstan": "^1.12.25",
+                "symfony/var-dumper": "^7.2.6"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "OpenAI\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenAI\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "OpenAI PHP for Laravel is a supercharged PHP API client that allows you to interact with the Open AI API",
+            "keywords": [
+                "GPT-3",
+                "api",
+                "client",
+                "codex",
+                "dall-e",
+                "language",
+                "laravel",
+                "natural",
+                "openai",
+                "php",
+                "processing",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/openai-php/laravel/issues",
+                "source": "https://github.com/openai-php/laravel/tree/v0.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-06-24T10:56:22+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
+        },
+        {
+            "name": "php-http/multipart-stream-builder",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/multipart-stream-builder.git",
+                "reference": "10086e6de6f53489cca5ecc45b6f468604d3460e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/10086e6de6f53489cca5ecc45b6f468604d3460e",
+                "reference": "10086e6de6f53489cca5ecc45b6f468604d3460e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/discovery": "^1.15",
+                "psr/http-factory-implementation": "^1.0"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.0",
+                "php-http/message": "^1.5",
+                "php-http/message-factory": "^1.0.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\MultipartStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "A builder class that help you create a multipart stream",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "multipart stream",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/multipart-stream-builder/issues",
+                "source": "https://github.com/php-http/multipart-stream-builder/tree/1.4.2"
+            },
+            "time": "2024-09-04T13:22:54+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -145,6 +145,11 @@ return [
         App\Providers\AuthServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+
+
+         // ...（他のサービスプロバイダ）
+        OpenAI\Laravel\ServiceProvider::class,
+
     ],
 
     'aliases' => [

--- a/backend/config/openai.php
+++ b/backend/config/openai.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI API Key and Organization
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your OpenAI API Key and organization. This will be
+    | used to authenticate with the OpenAI API - you can find your API key
+    | and organization on your OpenAI dashboard, at https://openai.com.
+    */
+
+    'api_key' => env('OPENAI_API_KEY'),
+    'organization' => env('OPENAI_ORGANIZATION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI API Project
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your OpenAI API project. This is used optionally in
+    | situations where you are using a legacy user API key and need association
+    | with a project. This is not required for the newer API keys.
+    */
+    'project' => env('OPENAI_PROJECT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI Base URL
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your OpenAI API base URL used to make requests. This
+    | is needed if using a custom API endpoint. Defaults to: api.openai.com/v1
+    */
+    'base_uri' => env('OPENAI_API_BASE_URL', 'https://api.openai.com/v1'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Request Timeout
+    |--------------------------------------------------------------------------
+    |
+    | The timeout may be used to specify the maximum number of seconds to wait
+    | for a response. By default, the client will time out after 30 seconds.
+    */
+
+    'request_timeout' => env('OPENAI_REQUEST_TIMEOUT', 30),
+];

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -34,5 +34,10 @@ return [
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
         ],
     ],
+     // ここから追記
+    'openai' => [
+        'api_key'  => env('OPENAI_API_KEY'),
+        'api_base' => env('OPENAI_API_BASE_URL', 'https://api.openai.com/v1'),
+    ],
 
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LearningLogController;
+use App\Http\Controllers\HintController;
+use App\Http\Controllers\ModelAnswerController;
+
+
 
 // Route::middleware('auth:sanctum')->group(function () {
    
@@ -11,4 +15,5 @@ Route::post('/learning_logs', [LearningLogController::class, 'LearningLogRegiste
 Route::get('/learning_logs', [LearningLogController::class, 'LearningLogShowList']);
 Route::get('/learning_logs/{id}', [LearningLogController::class, 'SpecificLearningLog']);
 Route::put('/learning_logs/{id}', [LearningLogController::class, 'UpdateLearningLog']);
-
+Route::post('/hints/generate', [HintController::class, 'generate']);
+Route::post('/model_answers/generate', [ModelAnswerController::class, 'generate']);

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,8 +18,8 @@ services:
     build:
       context: ./frontend
     volumes:
-    - ./frontend:/frontend
-    - /frontend/node_modules
+      - ./frontend:/frontend
+      - /frontend/node_modules
     ports:
       - "5173:5173"
     depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1599,6 +1600,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2470,6 +2480,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2535,6 +2583,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    //AI機能のための追加
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,13 @@
-import { useState, useEffect } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from "react";
+import reactLogo from "./assets/react.svg";
+import viteLogo from "/vite.svg";
+import "./App.css";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import TestHintApi from "./TestHintApi";
 
-function App() {
-  // const [count, setCount] = useState(0)
-  const [ping, setPing] = useState("")
-  const fetchPing = async () => {
-    await fetch("http://localhost:8000/ping").then(res => res.json()).then(response => setPing(response.message))
-  }
+import ChatHintApi from "./ChatHintApi";
 
+function Home({ ping, fetchPing }) {
   return (
     <>
       <div>
@@ -22,9 +20,7 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={fetchPing}>
-          {ping}
-        </button>
+        <button onClick={fetchPing}>{ping}</button>
         <p>
           Edit <code>src/App.jsx</code> and save to test HMR
         </p>
@@ -32,8 +28,31 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <hr />
+      {/* 追加：リンクでテストページに遷移 */}
+      <Link to="/test-hint">ヒントAPIテストページへ</Link>
     </>
-  )
+  );
 }
 
-export default App
+function App() {
+  const [ping, setPing] = useState("");
+  const fetchPing = async () => {
+    await fetch("http://localhost:8000/ping")
+      .then((res) => res.json())
+      .then((response) => setPing(response.message));
+  };
+
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home ping={ping} fetchPing={fetchPing} />} />
+        <Route path="/test-hint" element={<TestHintApi />} />
+
+        <Route path="/chat-hint" element={<ChatHintApi />} />
+      </Routes>
+    </Router>
+  );
+}
+
+export default App;


### PR DESCRIPTION
概要
ChatGPT API（openai-php/laravel）を使ったヒント生成API（/api/hints/generate）を新規実装

段階的なヒント、小出しヒント、ユーザー進捗へのフィードバック対応

模範解答生成API（/api/model-answers/generate）も新規追加（現状、簡易版）

.env.example に OPENAI_API_KEY など必要項目を追加

主な変更ファイル
backend/app/Http/Controllers/HintController.php

backend/app/Http/Controllers/ModelAnswerController.php

backend/config/services.php

backend/config/openai.php

backend/routes/api.php

frontend/src/App.jsx （APIテスト用UIのためのルーティング追加など）

動作確認
Postmanおよびフロント仮ページでAPI呼び出し、段階的ヒントの受信、模範解答の取得を確認済み

テスト用ファイル（ChatHintApi.jsx, TestHintApi.jsx）は コミット対象外

その他
OpenAIのAPIキーは各自 .env で管理してください（OPENAI_API_KEY 必須）

不明点やバグ等あればコメントください

