### PR TITLE
AIによるスキル分析・企業サジェストAPIと画面実装

### DIFF
--- a/backend/app/Http/Controllers/CompanySuggestController.php
+++ b/backend/app/Http/Controllers/CompanySuggestController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class CompanySuggestController extends Controller
+{
+    /** POST /api/companies/suggest */
+    public function suggest(Request $request)
+    {
+        /* ===== 1. 入力 ===== */
+        $income  = $request->input('income');
+        $jobType = $request->input('jobType');
+        $skills  = $request->input('skills', []);
+
+        $skillStr = implode(', ', array_map(
+            fn($k, $v) => "$k:レベル$v", array_keys($skills), $skills
+        ));
+
+        /* ===== 2. プロンプト ===== */
+        $prompt = <<<PROMPT
+あなたは日本のIT転職エージェントです。
+下記条件に『少しでも当てはまる』IT企業を **必ず10社** 生成し、
+**[ で始まる JSON 配列のみ** で返してください（文章は禁止）。
+
+■ 条件
+- 年収 : {$income}
+- 職種 : {$jobType}
+- スキル : {$skillStr}
+
+■ 厳守
+- 要素キー : id,name,description,matchRate,techStack,location,salaryRange
+- id=1〜10 連番 / matchRate=80〜100 (整数)
+- 架空企業可
+PROMPT;
+
+        /* ===== 3. ChatGPT 呼び出し ===== */
+        $raw = $this->askGPT($prompt, 'call');
+
+        /* ===== 4. デコード & 必要なら修正 ===== */
+        $companies = $this->safeDecode($raw);
+
+        if (count($companies) !== 10) {
+            $fixPrompt = "次の内容を『必ず 10 件の JSON 配列』に修正し返してください：\n{$raw}";
+            $raw  = $this->askGPT($fixPrompt, 'fix');
+            $companies = $this->safeDecode($raw);
+        }
+
+        /* ===== 5. フォールバック ===== */
+        if (!is_array($companies) || count($companies) === 0) {
+            $companies = [];
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'data'   => $companies,
+        ]);
+    }
+
+    /* ---------- ChatGPT 共通 ---------- */
+    private function askGPT(string $content, string $tag): string
+    {
+        $res = OpenAI::chat()->create([
+            'model' => env('OPENAI_MODEL', 'gpt-4o'),
+            'messages' => [
+                ['role'=>'system','content'=>'JSON 配列のみ返してください。文章は禁止。'],
+                ['role'=>'user',  'content'=>$content],
+            ],
+            // ★ response_format を外す → 配列そのまま返して OK
+            'max_tokens'  => 1800,
+            'temperature' => 0.8,
+        ]);
+
+        $raw = $res['choices'][0]['message']['content'] ?? '[]';
+        Log::info("AI raw response ({$tag})", ['raw'=>$raw]);
+        return $raw;
+    }
+
+    /* ---------- JSON デコード補助 ---------- */
+    private function safeDecode(string $json)
+    {
+        // --- ★ここから 追加：コードブロック除去 ---
+        $json = trim($json);
+        // 先頭の```jsonや```を削除
+        $json = preg_replace('/^```json\s*/', '', $json);
+        $json = preg_replace('/^```\s*/', '', $json);
+        // 末尾の```を削除
+        $json = preg_replace('/```$/', '', $json);
+        // 全角スペース→半角
+        $json = preg_replace('/\x{3000}/u', ' ', $json);
+        // 末尾カンマ除去
+        $json = preg_replace('/,\s*([\]\}])/', '$1', $json);
+        $json = trim($json);
+
+        $decoded = json_decode($json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            Log::warning('CompanySuggest: json_decode error', [
+                'error' => json_last_error_msg(),
+                'raw'   => mb_strimwidth($json, 0, 300, '…'),
+            ]);
+            return [];
+        }
+        // 1件のみオブジェクトだった場合
+        if (isset($decoded['id'])) {
+            return [$decoded];
+        }
+        return $decoded;
+    }
+}

--- a/backend/app/Http/Controllers/SkillAnalysisController.php
+++ b/backend/app/Http/Controllers/SkillAnalysisController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class SkillAnalysisController extends Controller
+{
+    public function analyze(Request $request)
+    {
+        return response()->json([
+            'status' => 'success',
+            'data' => [
+                'matchRate' => 85,
+                'skills' => $request->skills,
+                'advice' => 'あなたのスキルセットは十分に魅力的です！',
+                'roadmap' => [
+                    'Week 1' => 'React を強化しよう',
+                    'Week 2' => 'AWS の学習を始めよう',
+                ]
+            ]
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,12 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\LearningLogController;
 use App\Http\Controllers\HintController;
 use App\Http\Controllers\ModelAnswerController;
+use App\Http\Controllers\SkillAnalysisController;
+use App\Http\Controllers\CompanySuggestController;
+
+
+
+
 
 // Sanctum 認証用の CSRF Cookie 取得（React 側で最初に呼び出す）
 Route::get('/csrf-cookie', function () {
@@ -34,3 +40,10 @@ Route::middleware('auth:sanctum')->group(function () {
 // 認証なしでも使えるAPI（現状維持）
 Route::post('/hints/generate', [HintController::class, 'generate']);
 Route::post('/model_answers/generate', [ModelAnswerController::class, 'generate']);
+
+//企業表示
+
+Route::post('/analyze-skills', [SkillAnalysisController::class, 'analyze']);
+Route::options('/{any}', fn() => response('', 204))
+      ->where('any', '.*');   // ←プリフライト用の汎用 OPTIONS
+Route::post('/companies/suggest', [CompanySuggestController::class, 'suggest']);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ import CodeCoachPage from "./pages/CodeCoachPage";
 import { StepProvider } from "./contexts/StepContext";
 // import TestHintApi from "./TestHintApi";
 // import ChatHintApi from "./ChatHintApi";
+import CompanyListPage from "./pages/CompanyListPage";
+import CompanyAnalysisResultPage from "./pages/CompanyAnalysisResultPage";
 
 function App() {
   return (
@@ -25,14 +27,26 @@ function App() {
           <Route path="/annual-income" element={<AnnualIncomePage />} />
           <Route path="/job-type" element={<JobTypePage />} />
           <Route path="/skill-input" element={<SkillInputPage />} />
-          <Route path="/analysis-result/:id" element={<AnalysisResultPage />} />
+          {/* ★★★ ここを /analysis-result に修正 ★★★ */}
+          <Route path="/analysis-result" element={<AnalysisResultPage />} />
+
+          <Route path="/company-list" element={<CompanyListPage />} />
+
+          <Route
+            path="/company/:id/analysis-result"
+            element={<AnalysisResultPage />}
+          />
+
+          <Route
+            path="/company/:id/analysis-result"
+            element={<CompanyAnalysisResultPage />}
+          />
 
           {/* その他 */}
           <Route path="/home" element={<HomePage />} />
           <Route path="/code-coach" element={<CodeCoachPage />} />
           {/* <Route path="/test-hint" element={<TestHintApi />} />
           <Route path="/chat-hint" element={<ChatHintApi />} /> */}
-
         </Routes>
       </BrowserRouter>
     </StepProvider>

--- a/frontend/src/pages/AnalysisResultPage.jsx
+++ b/frontend/src/pages/AnalysisResultPage.jsx
@@ -1,42 +1,93 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom"; // ★ 追加
 import { StepContext } from "../contexts/StepContext";
+
+import { Radar } from "react-chartjs-2";
+import Chart from "chart.js/auto"; // eslint-disable-line no-unused-vars
+
 import "../styles/StepPage.css";
+import "../styles/AnalysisResultPage.css";
 
 const AnalysisResultPage = () => {
+  /* ---------- context / state ---------- */
   const { formData } = useContext(StepContext);
-  const [result, setResult] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate(); // ★ 追加
+
+  const [result, setResult] = useState(formData.analysisResult || null);
+  const [loading, setLoading] = useState(!formData.analysisResult);
   const [error, setError] = useState(null);
 
+  /* ---------- fallback fetch ---------- */
   useEffect(() => {
-    const fetchAnalysis = async () => {
+    if (formData.analysisResult) return;
+
+    (async () => {
+      setLoading(true);
       try {
         const res = await fetch("http://localhost:8000/api/analyze-skills", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(formData),
         });
-
         const data = await res.json();
-
         if (res.ok && data.status === "success") {
           setResult(data.data);
         } else {
           throw new Error(data.message || "分析に失敗しました。");
         }
-      } catch (err) {
-        console.error("分析エラー:", err);
+      } catch {
         setError("分析に失敗しました。もう一度お試しください。");
       } finally {
         setLoading(false);
       }
-    };
-
-    fetchAnalysis();
+    })();
   }, [formData]);
 
+  /* ---------- Radar Chart data ---------- */
+  const chartData = useMemo(() => {
+    if (!result?.skills) return null;
+
+    const labels = Object.keys(result.skills);
+    const current = Object.values(result.skills);
+    const target = result.targetLevels
+      ? labels.map((k) => result.targetLevels[k] ?? 4)
+      : labels.map(() => 4);
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: "目標レベル",
+          data: target,
+          borderColor: "rgba(255,99,132,0.9)",
+          backgroundColor: "rgba(255,99,132,0.2)",
+          pointRadius: 3,
+        },
+        {
+          label: "あなたの現在レベル",
+          data: current,
+          borderColor: "rgba(54,162,235,0.9)",
+          backgroundColor: "rgba(54,162,235,0.15)",
+          pointRadius: 3,
+        },
+      ],
+    };
+  }, [result]);
+
+  /* ---------- ギャップ一覧 ---------- */
+  const gapList = useMemo(() => {
+    if (!result?.skills) return [];
+    const target = result.targetLevels || {};
+    return Object.entries(result.skills)
+      .map(([skill, lvl]) => {
+        const goal = target[skill] ?? 4;
+        return { skill, current: lvl, goal, diff: goal - lvl };
+      })
+      .filter((g) => g.diff > 0)
+      .sort((a, b) => b.diff - a.diff);
+  }, [result]);
+
+  /* ---------- render ---------- */
   return (
     <>
       <header>
@@ -44,6 +95,7 @@ const AnalysisResultPage = () => {
       </header>
 
       <div className="step-page">
+        {/* 進捗バー */}
         <div className="progress-bar">
           <span>年収</span>
           <span>職種</span>
@@ -52,37 +104,85 @@ const AnalysisResultPage = () => {
           <span className="active">結果</span>
         </div>
 
-        <h2 className="page-title">分析結果</h2>
+        <h2 className="page-title">スキル一致率診断結果</h2>
 
         {loading ? (
           <p>分析中です...</p>
         ) : error ? (
           <p style={{ color: "red" }}>{error}</p>
         ) : result ? (
-          <div className="analysis-result">
-            <p><strong>マッチ率:</strong> {result.matchRate}%</p>
+          <>
+            {/* -------- 上段 -------- */}
+            <div className="result-top">
+              <div className="radar-wrapper">
+                {chartData && <Radar data={chartData} />}
+                <div className="legend">
+                  <span className="legend-target">■ 目標レベル</span>
+                  <span className="legend-current">■ 現在レベル</span>
+                </div>
+              </div>
 
-            <h3>スキル評価</h3>
-            <ul>
-              {Object.entries(result.skills).map(([skill, level]) => (
-                <li key={skill}>
-                  {skill}: レベル {level}
-                </li>
-              ))}
-            </ul>
+              <div className="gap-info">
+                <p className="match-rate">
+                  あなたの現在のスキル一致率は：
+                  <strong>{Number(result.matchRate).toFixed(1)}%</strong> です
+                </p>
+                <h4>ギャップ詳細（優先度順）</h4>
+                <ul className="gap-list">
+                  {gapList.length === 0 ? (
+                    <li>大きなギャップはありません 🎉</li>
+                  ) : (
+                    gapList.map((g) => (
+                      <li key={g.skill}>
+                        <span className="skill-name">{g.skill}</span>
+                        ：必要 <b>{g.goal}</b> / 現在 <b>{g.current}</b>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+            </div>
 
-            <h3>アドバイス</h3>
-            <p>{result.advice}</p>
+            {/* -------- 下段 -------- */}
+            <div className="result-bottom">
+              <div className="advice-block">
+                <h3>個別ヒント（学習アドバイス）</h3>
+                <ul>
+                  {result.advice
+                    ? result.advice
+                        .split("\n")
+                        .map((row, i) => <li key={i}>{row}</li>)
+                    : "－"}
+                </ul>
+              </div>
 
-            <h3>学習ロードマップ</h3>
-            <ul>
-              {Object.entries(result.roadmap).map(([week, task]) => (
-                <li key={week}>
-                  <strong>{week}:</strong> {task}
-                </li>
-              ))}
-            </ul>
-          </div>
+              <div className="roadmap-block">
+                <h3>あなた専用の学習ロードマップ</h3>
+                <ul>
+                  {result.roadmap
+                    ? Object.entries(result.roadmap).map(([w, t]) => (
+                        <li key={w}>
+                          <strong>{w}：</strong>
+                          {t}
+                        </li>
+                      ))
+                    : "－"}
+                </ul>
+              </div>
+            </div>
+
+            {/* -------- アクションボタン -------- */}
+            <div className="action-buttons">
+              <button onClick={() => navigate("/career-coach")}>
+                ✏️ キャリアコーチへ
+              </button>
+
+              {/* ★ ここで /code-coach へ遷移 */}
+              <button onClick={() => navigate("/code-coach")}>
+                💡 コードコーチへ
+              </button>
+            </div>
+          </>
         ) : (
           <p>結果が取得できませんでした。</p>
         )}

--- a/frontend/src/pages/CompanyAnalysisResultPage.jsx
+++ b/frontend/src/pages/CompanyAnalysisResultPage.jsx
@@ -1,0 +1,28 @@
+// src/pages/CompanyAnalysisResultPage.jsx
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+const CompanyAnalysisResultPage = () => {
+  const location = useLocation();
+  const company = location.state?.company;
+
+  if (!company) {
+    return <div>企業情報が取得できませんでした。</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: 700, margin: "0 auto", padding: 24 }}>
+      <h2>{company.name}</h2>
+      <div>📍 {company.location}</div>
+      <div>💰 {company.salaryRange}</div>
+      <div>💻 技術: {company.techStack?.join(", ")}</div>
+      <div style={{ margin: "12px 0" }}>{company.description}</div>
+      <div>
+        マッチ度: <b>{company.matchRate}%</b>
+      </div>
+      {/* 必要ならここに会社ごとの追加分析やスキル可視化などを拡張 */}
+    </div>
+  );
+};
+
+export default CompanyAnalysisResultPage;

--- a/frontend/src/pages/CompanyListPage.jsx
+++ b/frontend/src/pages/CompanyListPage.jsx
@@ -1,0 +1,87 @@
+import React, { useContext, useEffect, useState } from "react";
+import { StepContext } from "../contexts/StepContext";
+import { useNavigate } from "react-router-dom";
+
+const CompanyListPage = () => {
+  const { formData } = useContext(StepContext);
+  const [companies, setCompanies] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchCompanies = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await fetch("http://localhost:8000/api/companies/suggest", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(formData),
+        });
+        const data = await res.json();
+        // ここで受け取った値をconsole.logしてチェックもできる
+        // console.log("API result:", data);
+
+        if (data.status === "success" && Array.isArray(data.data)) {
+          setCompanies(data.data);
+        } else {
+          setCompanies([]);
+          setError(data.message || "取得に失敗しました");
+        }
+      } catch (e) {
+        setError("サーバー通信に失敗しました");
+        setCompanies([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCompanies();
+  }, [formData]);
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: 24 }}>
+      <h2>あなたにマッチする企業（{companies.length}社）</h2>
+      {loading ? (
+        <div>読み込み中...</div>
+      ) : error ? (
+        <div style={{ color: "red" }}>{error}</div>
+      ) : companies.length === 0 ? (
+        <div>該当する企業がありません。</div>
+      ) : (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 24 }}>
+          {companies.map((c, i) => (
+            <div
+              key={c.id || i}
+              style={{
+                border: "1px solid #ccc",
+                borderRadius: 12,
+                padding: 18,
+                width: 250,
+                background: "#fafdff",
+                cursor: "pointer",
+              }}
+              onClick={() =>
+                navigate(`/company/${c.id || i}/analysis-result`, {
+                  state: { company: c },
+                })
+              }
+            >
+              <h3>{c.name}</h3>
+              <div>
+                📍 {c.location} / 💻 {c.techStack?.join(", ")}
+              </div>
+              <div>💰 {c.salaryRange}</div>
+              <div style={{ fontWeight: "bold", marginTop: 8 }}>
+                マッチ度: {c.matchRate}%
+              </div>
+              <div style={{ marginTop: 8 }}>{c.description}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CompanyListPage;

--- a/frontend/src/styles/AnalysisResultPage.css
+++ b/frontend/src/styles/AnalysisResultPage.css
@@ -1,0 +1,104 @@
+/* 全体幅を絞り、中央寄せ */
+.step-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+/* タイトル下の上段エリア（チャート＋ギャップ） */
+.result-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  align-items: flex-start;
+  margin-top: 24px;
+}
+
+/* レーダーチャート側 */
+.radar-wrapper {
+  width: 320px;
+  min-width: 280px;
+}
+
+.legend {
+  font-size: 13px;
+  margin-top: 6px;
+}
+.legend-target {
+  color: #e74c3c;
+  margin-right: 8px;
+}
+.legend-current {
+  color: #3498db;
+}
+
+/* ギャップ一覧 */
+.gap-info {
+  flex: 1;
+  min-width: 240px;
+}
+.match-rate strong {
+  font-size: 26px;
+  color: #007bff;
+}
+.gap-list {
+  padding-left: 20px;
+  margin-top: 6px;
+}
+.gap-list li {
+  margin-bottom: 4px;
+}
+
+/* 下段：アドバイス＆ロードマップ*/
+.result-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  margin-top: 36px;
+}
+
+.advice-block,
+.roadmap-block {
+  flex: 1;
+  min-width: 260px;
+}
+
+.advice-block ul,
+.roadmap-block ul {
+  padding-left: 18px;
+  font-size: 14px;
+}
+
+.advice-block li,
+.roadmap-block li {
+  margin-bottom: 4px;
+}
+
+/* アクションボタン */
+.action-buttons {
+  max-width: 480px;
+  margin: 40px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.action-buttons button {
+  padding: 12px;
+  font-size: 16px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.action-buttons .secondary {
+  background: #f5f5f5;
+}
+
+/* 小さい画面での折返し */
+@media (max-width: 600px) {
+  .radar-wrapper {
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
目的
ユーザーが入力したスキルセット・興味から、AIを使って強み分析やマッチする企業一覧を提案できる機能を追加

フロントからの一連の体験（スキル入力→分析→企業サジェスト→企業リスト表示）を整備

追加・変更内容
backend

SkillAnalysisController.php … スキル分析AI連携API

CompanySuggestController.php … 企業サジェストAPI

routes/api.php … 上記APIルートを追加

frontend

SkillInputPage.jsx … スキル入力画面

AnalysisResultPage.jsx … 分析結果＋強み表示

CompanyListPage.jsx … サジェスト企業一覧ページ

CompanyAnalysisResultPage.jsx … 企業マッチ詳細表示ページ

App.jsx … ルーティング追加

AnalysisResultPage.css … 新規画面用スタイル

動作例
ユーザーがスキル入力→「分析」ボタン

AIでスキル傾向/強みを解析→フィードバック表示

マッチする企業名・特徴をAIがサジェスト→一覧で表示

企業詳細も確認できる

注意点・レビュー観点
現状はDB設計変更なしでAIの回答内容をそのままリスト化（企業データベース連携は将来検討）

テスト用ページは含めていません

サジェスト精度・回答速度など、今後改善余地あり

